### PR TITLE
SEC-2312: patch form-data to 4.0.6 (CVE-2025-7501)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@modelcontextprotocol/sdk": "0.5.0",
                 "dotenv": "^16.3.1",
-                "jsforce": "^3.7.0"
+                "jsforce": "^3.10.17"
             },
             "bin": {
                 "salesforce-connector": "dist/index.js"
@@ -35,16 +35,52 @@
             }
         },
         "node_modules/@babel/runtime-corejs3": {
-            "version": "7.27.0",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/@babel/runtime-corejs3/-/runtime-corejs3-7.27.0.tgz",
-            "integrity": "sha512-UWjX6t+v+0ckwZ50Y5ShZLnlk95pP5MyW/pon9tiYzl3+18pkTHTFNTKr7rQbfRXPkowt2QAn30o1b6oswszew==",
+            "version": "7.29.7",
+            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz",
+            "integrity": "sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==",
             "license": "MIT",
             "dependencies": {
-                "core-js-pure": "^3.30.2",
-                "regenerator-runtime": "^0.14.0"
+                "core-js-pure": "^3.48.0"
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@inquirer/external-editor": {
+            "version": "1.0.3",
+            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+            "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+            "license": "MIT",
+            "dependencies": {
+                "chardet": "^2.1.1",
+                "iconv-lite": "^0.7.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+            "version": "0.7.2",
+            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/@modelcontextprotocol/sdk": {
@@ -74,22 +110,10 @@
             "version": "22.14.1",
             "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/@types/node/-/node-22.14.1.tgz",
             "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
-            }
-        },
-        "node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "license": "MIT",
-            "dependencies": {
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6.0.0"
             }
         },
         "node_modules/ansi-escapes": {
@@ -264,9 +288,9 @@
             }
         },
         "node_modules/chardet": {
-            "version": "0.7.0",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/chardet/-/chardet-0.7.0.tgz",
-            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "version": "2.2.0",
+            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/chardet/-/chardet-2.2.0.tgz",
+            "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
             "license": "MIT"
         },
         "node_modules/cli-cursor": {
@@ -367,9 +391,9 @@
             }
         },
         "node_modules/core-js": {
-            "version": "3.41.0",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/core-js/-/core-js-3.41.0.tgz",
-            "integrity": "sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA==",
+            "version": "3.49.0",
+            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/core-js/-/core-js-3.49.0.tgz",
+            "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
             "hasInstallScript": true,
             "license": "MIT",
             "funding": {
@@ -378,9 +402,9 @@
             }
         },
         "node_modules/core-js-pure": {
-            "version": "3.41.0",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/core-js-pure/-/core-js-pure-3.41.0.tgz",
-            "integrity": "sha512-71Gzp96T9YPk63aUvE5Q5qP+DryB4ZloUZPSOebGM88VNw8VNfvdA7z6kGA8iGOTEzAomsRidp4jXSmUIJsL+Q==",
+            "version": "3.49.0",
+            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/core-js-pure/-/core-js-pure-3.49.0.tgz",
+            "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
             "hasInstallScript": true,
             "license": "MIT",
             "funding": {
@@ -407,27 +431,10 @@
             "license": "MIT"
         },
         "node_modules/csv-stringify": {
-            "version": "6.5.2",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/csv-stringify/-/csv-stringify-6.5.2.tgz",
-            "integrity": "sha512-RFPahj0sXcmUyjrObAK+DOWtMvMIFV328n4qZJhgX3x2RqkQgOTU2mCUmiFR0CzM6AzChlRSUErjiJeEt8BaQA==",
+            "version": "6.8.0",
+            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/csv-stringify/-/csv-stringify-6.8.0.tgz",
+            "integrity": "sha512-Ya0OOHb6XbgPaZKH7dcdmwXe3azUS0TwmlbVdS75HoAhnHApSkiQcfEJoC/s5WwGsrXwOjBDr3FTmCZPjkssgg==",
             "license": "MIT"
-        },
-        "node_modules/debug": {
-            "version": "4.4.0",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/debug/-/debug-4.4.0.tgz",
-            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/defaults": {
             "version": "1.0.4",
@@ -510,9 +517,9 @@
             }
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -543,32 +550,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"
-            }
-        },
-        "node_modules/external-editor": {
-            "version": "3.1.0",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/external-editor/-/external-editor-3.1.0.tgz",
-            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-            "license": "MIT",
-            "dependencies": {
-                "chardet": "^0.7.0",
-                "iconv-lite": "^0.4.24",
-                "tmp": "^0.0.33"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/external-editor/node_modules/iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/faye": {
@@ -616,15 +597,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.2",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/form-data/-/form-data-4.0.2.tgz",
-            "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+            "version": "4.0.6",
+            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -754,9 +736,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -786,19 +768,6 @@
             "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/http-parser-js/-/http-parser-js-0.5.10.tgz",
             "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
             "license": "MIT"
-        },
-        "node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
         },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
@@ -851,16 +820,16 @@
             "license": "ISC"
         },
         "node_modules/inquirer": {
-            "version": "8.2.6",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/inquirer/-/inquirer-8.2.6.tgz",
-            "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
+            "version": "8.2.7",
+            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/inquirer/-/inquirer-8.2.7.tgz",
+            "integrity": "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==",
             "license": "MIT",
             "dependencies": {
+                "@inquirer/external-editor": "^1.0.0",
                 "ansi-escapes": "^4.2.1",
                 "chalk": "^4.1.1",
                 "cli-cursor": "^3.1.0",
                 "cli-width": "^3.0.0",
-                "external-editor": "^3.0.3",
                 "figures": "^3.0.0",
                 "lodash": "^4.17.21",
                 "mute-stream": "0.0.8",
@@ -960,26 +929,25 @@
             }
         },
         "node_modules/jsforce": {
-            "version": "3.7.0",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/jsforce/-/jsforce-3.7.0.tgz",
-            "integrity": "sha512-KKymZA7MaVJP8NgZrKexK4Kx+ZW422N96OaOwvoHxwlIjWOYPsP51Y14i+6h+gLnTOE045djpoI/PRQst1QWdQ==",
+            "version": "3.10.17",
+            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/jsforce/-/jsforce-3.10.17.tgz",
+            "integrity": "sha512-+pUnQpZUNYYxWRJyAc/L+Q7xCShJgZ/7XN+4Cw2I60cA/rt8Z1kRFT3WP6Eng/c7Qb9VnNy9x0XwjEv5NUu+vA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.23.1",
-                "@babel/runtime-corejs3": "^7.23.1",
+                "@babel/runtime": "^7.27.0",
+                "@babel/runtime-corejs3": "^7.28.3",
                 "@sindresorhus/is": "^4",
                 "base64url": "^3.0.1",
                 "commander": "^4.0.1",
-                "core-js": "^3.33.0",
+                "core-js": "^3.45.0",
                 "csv-parse": "^5.5.2",
-                "csv-stringify": "^6.4.4",
+                "csv-stringify": "^6.6.0",
                 "faye": "^1.4.0",
-                "form-data": "^4.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "inquirer": "^8.2.6",
+                "form-data": "^4.0.4",
+                "inquirer": "^8.2.7",
                 "multistream": "^3.1.0",
-                "node-fetch": "^2.6.1",
                 "open": "^7.0.0",
+                "undici": "^8.5.0",
                 "xml2js": "^0.6.2"
             },
             "bin": {
@@ -987,13 +955,13 @@
                 "jsforce-gen-schema": "bin/jsforce-gen-schema"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "version": "4.18.1",
+            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
         },
         "node_modules/log-symbols": {
@@ -1074,12 +1042,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "license": "MIT"
-        },
         "node_modules/multistream": {
             "version": "3.1.0",
             "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/multistream/-/multistream-3.1.0.tgz",
@@ -1095,26 +1057,6 @@
             "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/mute-stream/-/mute-stream-0.0.8.tgz",
             "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "license": "ISC"
-        },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "license": "MIT",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/once": {
             "version": "1.4.0",
@@ -1178,15 +1120,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/path-is-absolute": {
@@ -1486,18 +1419,6 @@
             "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
             "license": "MIT"
         },
-        "node_modules/tmp": {
-            "version": "0.0.33",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "license": "MIT",
-            "dependencies": {
-                "os-tmpdir": "~1.0.2"
-            },
-            "engines": {
-                "node": ">=0.6.0"
-            }
-        },
         "node_modules/toidentifier": {
             "version": "1.0.1",
             "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1518,12 +1439,6 @@
             "engines": {
                 "node": ">=16"
             }
-        },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "license": "MIT"
         },
         "node_modules/tslib": {
             "version": "2.8.1",
@@ -1569,11 +1484,20 @@
                 "node": ">=14.17"
             }
         },
+        "node_modules/undici": {
+            "version": "8.5.0",
+            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/undici/-/undici-8.5.0.tgz",
+            "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=22.19.0"
+            }
+        },
         "node_modules/undici-types": {
             "version": "6.21.0",
             "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/undici-types/-/undici-types-6.21.0.tgz",
             "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/unpipe": {
@@ -1600,12 +1524,6 @@
                 "defaults": "^1.0.3"
             }
         },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "license": "BSD-2-Clause"
-        },
         "node_modules/websocket-driver": {
             "version": "0.7.4",
             "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -1627,16 +1545,6 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=0.8.0"
-            }
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://simondata.jfrog.io/artifactory/api/npm/npm/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "license": "MIT",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
     "dependencies": {
         "@modelcontextprotocol/sdk": "0.5.0",
         "dotenv": "^16.3.1",
-        "jsforce": "^3.7.0"
+        "jsforce": "^3.10.17"
+    },
+    "overrides": {
+        "form-data": "^4.0.5"
     },
     "devDependencies": {
         "@types/node": "^22.10.1",


### PR DESCRIPTION
https://simondata.atlassian.net/browse/SECURITY-2312

## Summary

- Bumps `jsforce` **^3.7.0 → ^3.10.17** — low risk upgrade with no breaking changes to any Connection APIs used in this codebase (`query`, `sobject`, `search`, `describe`, `metadata`, `tooling`, both `Connection` constructors, `conn.login`). Notable improvements include native fetch (v3.10.17) and various bug fixes.
- Adds `overrides: { "form-data": "^4.0.5" }` to enforce the patched floor, since jsforce itself only declares `^4.0.4`; resolves transitively to **form-data 4.0.6** (resolves ORCA-8421701 / CVE-2025-7501)
- TypeScript build confirmed clean against jsforce 3.10.17

> **Note:** jsforce@3.10.17 declares `engines.node >=22`; the project currently targets `>=14`. The build passes with a warning on Node 20. Aligning the Node engine requirement is a separate follow-up concern.

## Test plan

- [ ] Verify `npm audit` no longer flags `form-data`
- [ ] Confirm Orca scan clears ORCA-8421701
- [ ] Smoke test Salesforce connection (username/password and OAuth flows) against a sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)